### PR TITLE
feat : Application rollback

### DIFF
--- a/src/cranecloud/__init__.py
+++ b/src/cranecloud/__init__.py
@@ -1,12 +1,13 @@
-from src.cranecloud.commands.apps import apps_group
-from src.cranecloud.commands.clusters import clusters_group
+from src.cranecloud.commands.apps import apps , revisions
+from src.cranecloud.commands.clusters import clusters
 import click
 from os.path import join, dirname
 from dotenv import load_dotenv
 from src.cranecloud.utils.config import create_config
-from src.cranecloud.commands.user_management import user_group
-from src.cranecloud.commands.projects import projects_group
-from src.cranecloud.commands.config_management import config_group
+from src.cranecloud.commands.user_management import user
+from src.cranecloud.commands.projects import projects
+from src.cranecloud.commands.config_management import config
+
 
 
 dotenv_path = join(dirname(__file__), '.env')
@@ -17,10 +18,32 @@ load_dotenv(dotenv_path)
 def cli():
     pass
 
+#Users Section
+cli.add_command(user)
 
-cli = click.CommandCollection(
-    sources=[user_group, projects_group, apps_group, clusters_group, config_group])
+
+#Projects section
+cli.add_command(projects)
+
+
+# Apps section
+apps.add_command(revisions)
+cli.add_command(apps)
+
+# Clusters section
+cli.add_command(clusters)
+
+
+# Config section
+cli.add_command(config)
+
+
+
+
 
 
 def create_initial_config():
     create_config()
+
+if __name__ == '__main__':
+    cli()

--- a/src/cranecloud/commands/apps.py
+++ b/src/cranecloud/commands/apps.py
@@ -19,6 +19,18 @@ def apps():
     '''
     pass
 
+@click.group()
+def revisions_group():
+    pass
+
+
+@revisions_group.group(name='revisions')
+def revisions():
+    '''
+    Revisions management commands.
+    '''
+    pass
+
 
 @apps.command('list', help='List apps in project')
 @click.option('-p', '--project_id', type=click.UUID, help='Project ID')
@@ -106,7 +118,7 @@ def get_app_details(app_id):
                 'Please check your internet connection or try again later.')
 
 
-@apps.command('delete', help='Delete App')
+@apps.command('delete', help='Delete App [Example : cranecloud apps delete <application id>]')
 @click.argument('app_id', type=click.UUID)
 def delete_app(app_id):
     '''Delete app.'''
@@ -229,9 +241,9 @@ def update_app(app_id, name, image, command, replicas, port, env):
                 'Please check your internet connection or try again later.')
 
 
-@apps.command('revisions', help='List app revisions')
+@revisions.command('list', help='List app revisions')
 @click.argument('app_id', type=click.UUID)
-@click.option('-p', '--page', type=int, help='Page' , required=False)
+@click.option('--page', type=int, help='Page' , required=False)
 def get_revisions(app_id , page):
     '''Get application revisions .'''
     click.echo('Getting app revisions ... ')
@@ -271,18 +283,18 @@ def get_revisions(app_id , page):
 
 
 
-@apps.command('rollback', help='Rolling back an application')
-@click.option('-v', '--version', type=str, help='App revision id of the app to roll back to')
+@revisions.command('update', help='Update an application to a specific revision id')
+@click.option('-r', '--revision', type=str, help='Revision id of the application' , required = True)
 @click.argument('app_id', type=click.UUID)
-def rollback_app(app_id , version):
-    '''Make an app roll back.'''
-    click.echo('Rolling back app...')
+def update_app(app_id , revision):
+    '''Make an app update.'''
+    click.echo(f'Updating application to revision {revision} ...')
     try:
         token = get_token()
 
 
         response = requests.post(
-            f'{API_BASE_URL}/apps/{app_id}/revise/{version}',
+            f'{API_BASE_URL}/apps/{app_id}/revise/{revision}',
             headers={'Authorization': f'Bearer {token}'}
         )
         response.raise_for_status()
@@ -305,3 +317,6 @@ def rollback_app(app_id , version):
 
     
     
+
+
+


### PR DESCRIPTION
# Description

This feature is meant to support application rollbacks in th CLI application based on the `app_id` and `revision_id` of the application.

Application revisions will be returned through the `cranecloud apps revisions <app_id> --page <page>` . The `--page` option is optional .

## How Can This Be Tested?

This can be tested by using the command `cranecloud apps rollback <app_id> --version <version_id>` where the `app_id` is the application id and `version_id` is the version id to be rolled back to gotten from the app details in the CLI application.

## Trello ticket

https://trello.com/c/BspdwHrg/1823-implement-app-roll-backs-cli-app

https://trello.com/c/Tvwh3SsJ/1828-fetching-app-revisions-in-the-cli-app