### PR TITLE
fix: update login to use 'username' instead of 'name' from API response

### DIFF
--- a/src/cranecloud/commands/user_management.py
+++ b/src/cranecloud/commands/user_management.py
@@ -41,7 +41,7 @@ def login(email, password):
             keyring.set_password("cranecloud", "user_id", user_body['id'])
             write_config('current_user', {
                 'id': user_body['id'],
-                'name': user_body['name'],
+                'name': user_body['username'],
                 'email': user_body['email']})
             click.echo("Login successful!")
         else:


### PR DESCRIPTION
Description
This PR updates the login function to correctly use the 'username' key from the API response instead of 'name'. This ensures that the current user's configuration is stored with the appropriate identifier expected by the application.

Changes Made
Replaced user_body['name'] with user_body['username'] during login

Why this is needed
The previous key 'name' caused incorrect or missing user information to be stored in the config, which could affect user identification or session handling.